### PR TITLE
Add all the supported events

### DIFF
--- a/core/src/main/scala/io/github/shogowada/scalajs/reactjs/VirtualDOM.scala
+++ b/core/src/main/scala/io/github/shogowada/scalajs/reactjs/VirtualDOM.scala
@@ -2,41 +2,177 @@ package io.github.shogowada.scalajs.reactjs
 
 import io.github.shogowada.scalajs.reactjs.classes.specs.ReactClassSpec
 import io.github.shogowada.scalajs.reactjs.elements.{ReactElement, ReactHTMLElement}
-import io.github.shogowada.scalajs.reactjs.events.SyntheticEvent
+import io.github.shogowada.scalajs.reactjs.events._
 import io.github.shogowada.statictags._
 
 import scala.language.implicitConversions
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 
+trait EventVirtualDOMAttributes {
+
+  trait OnEventAttribute[Event <: SyntheticEvent] extends AttributeSpec {
+    val name: String
+
+    def :=(callback: js.Function0[_]): Attribute[js.Function0[_]] = {
+      Attribute(name = name, value = callback)
+    }
+
+    def :=(callback: js.Function1[Event, _]): Attribute[js.Function1[Event, _]] = {
+      Attribute(name = name, value = callback)
+    }
+  }
+
+  // Animation Events
+  case class OnAnimationEventAttribute(name: String) extends OnEventAttribute[AnimationSyntheticEvent]
+
+  lazy val onAnimationStart = OnAnimationEventAttribute("onAnimationStart")
+  lazy val onAnimationEnd = OnAnimationEventAttribute("onAnimationEnd")
+  lazy val onAnimationIteration = OnAnimationEventAttribute("onAnimationIteration")
+
+  // Clipboard Events
+  case class OnClipboardEventAttribute(name: String) extends OnEventAttribute[ClipboardSyntheticEvent]
+
+  lazy val onCopy = OnClipboardEventAttribute("onCopy")
+  lazy val onCut = OnClipboardEventAttribute("onCut")
+  lazy val onPaste = OnClipboardEventAttribute("onPaste")
+
+  // Composition Events
+  case class OnCompositionEventAttribute(name: String) extends OnEventAttribute[CompositionSyntheticEvent]
+
+  lazy val onCompositionEnd = OnCompositionEventAttribute("onCompositionEnd")
+  lazy val onCompositionStart = OnCompositionEventAttribute("onCompositionStart")
+  lazy val onCompositionUpdate = OnCompositionEventAttribute("onCompositionUpdate")
+
+  // Focus Events
+  case class OnFocusEventAttribute(name: String) extends OnEventAttribute[FocusSyntheticEvent]
+
+  lazy val onFocus = OnFocusEventAttribute("onFocus")
+  lazy val onBlur = OnFocusEventAttribute("onBlur")
+
+  // Form Events
+  case class OnFormEventAttribute[FormEvent <: FormSyntheticEvent[_]](name: String) extends OnEventAttribute[FormEvent]
+
+  lazy val onChange = OnFormEventAttribute("onChange")
+  lazy val onInput = OnFormEventAttribute("onInput")
+  lazy val onSubmit = OnFormEventAttribute("onSubmit")
+
+  // Image Events
+  case class OnImageEventAttribute(name: String) extends OnEventAttribute[ImageSyntheticEvent]
+
+  lazy val onLoad = OnImageEventAttribute("onLoad")
+
+  // onError conflicts with Media Events. Conflicts are treated specially at the bottom of this trait.
+  // lazy val onError = OnImageEventAttribute("onError")
+
+  // Keyboard Events
+  case class OnKeyboardEventAttribute(name: String) extends OnEventAttribute[KeyboardSyntheticEvent]
+
+  lazy val onKeyDown = OnKeyboardEventAttribute("onKeyDown")
+  lazy val onKeyPress = OnKeyboardEventAttribute("onKeyPress")
+  lazy val onKeyUp = OnKeyboardEventAttribute("onKeyUp")
+
+  // Media Events
+  case class OnMediaEventAttribute(name: String) extends OnEventAttribute[MediaSyntheticEvent]
+
+  lazy val onAbort = OnMediaEventAttribute("onAbort")
+  lazy val onCanPlay = OnMediaEventAttribute("onCanPlay")
+  lazy val onCanPlayThrough = OnMediaEventAttribute("onCanPlayThrough")
+  lazy val onDurationChange = OnMediaEventAttribute("onDurationChange")
+  lazy val onEmptied = OnMediaEventAttribute("onEmptied")
+  lazy val onEncrypted = OnMediaEventAttribute("onEncrypted")
+  lazy val onEnded = OnMediaEventAttribute("onEnded")
+  // onError conflicts with Image Events. Conflicts are treated specially at the bottom of this trait.
+  // lazy val onError = OnMediaEventAttribute("onError")
+  lazy val onLoadedData = OnMediaEventAttribute("onLoadedData")
+  lazy val onLoadedMetadata = OnMediaEventAttribute("onLoadedMetadata")
+  lazy val onLoadStart = OnMediaEventAttribute("onLoadStart")
+  lazy val onPause = OnMediaEventAttribute("onPause")
+  lazy val onPlay = OnMediaEventAttribute("onPlay")
+  lazy val onPlaying = OnMediaEventAttribute("onPlaying")
+  lazy val onProgress = OnMediaEventAttribute("onProgress")
+  lazy val onRateChange = OnMediaEventAttribute("onRateChange")
+  lazy val onSeeked = OnMediaEventAttribute("onSeeked")
+  lazy val onSeeking = OnMediaEventAttribute("onSeeking")
+  lazy val onStalled = OnMediaEventAttribute("onStalled")
+  lazy val onSuspend = OnMediaEventAttribute("onSuspend")
+  lazy val onTimeUpdate = OnMediaEventAttribute("onTimeUpdate")
+  lazy val onVolumeChange = OnMediaEventAttribute("onVolumeChange")
+  lazy val onWaiting = OnMediaEventAttribute("onWaiting")
+
+  // Mouse Events
+  case class OnMouseEventAttribute(name: String) extends OnEventAttribute[MouseSyntheticEvent]
+
+  lazy val onClick = OnMouseEventAttribute("onClick")
+  lazy val onContextMenu = OnMouseEventAttribute("onContextMenu")
+  lazy val onDoubleClick = OnMouseEventAttribute("onDoubleClick")
+  lazy val onDrag = OnMouseEventAttribute("onDrag")
+  lazy val onDragEnd = OnMouseEventAttribute("onDragEnd")
+  lazy val onDragEnter = OnMouseEventAttribute("onDragEnter")
+  lazy val onDragExit = OnMouseEventAttribute("onDragExit")
+  lazy val onDragLeave = OnMouseEventAttribute("onDragLeave")
+  lazy val onDragOver = OnMouseEventAttribute("onDragOver")
+  lazy val onDragStart = OnMouseEventAttribute("onDragStart")
+  lazy val onDrop = OnMouseEventAttribute("onDrop")
+  lazy val onMouseDown = OnMouseEventAttribute("onMouseDown")
+  lazy val onMouseEnter = OnMouseEventAttribute("onMouseEnter")
+  lazy val onMouseLeave = OnMouseEventAttribute("onMouseLeave")
+  lazy val onMouseMove = OnMouseEventAttribute("onMouseMove")
+  lazy val onMouseOut = OnMouseEventAttribute("onMouseOut")
+  lazy val onMouseOver = OnMouseEventAttribute("onMouseOver")
+  lazy val onMouseUp = OnMouseEventAttribute("onMouseUp")
+
+  // Selection Events
+  case class OnSelectionEventAttribute(name: String) extends OnEventAttribute[SelectionSyntheticEvent]
+
+  lazy val onSelect = OnSelectionEventAttribute("onSelect")
+
+  // Touch Events
+  case class OnTouchEventAttribute(name: String) extends OnEventAttribute[TouchSyntheticEvent]
+
+  lazy val onTouchCancel = OnTouchEventAttribute("onTouchCancel")
+  lazy val onTouchEnd = OnTouchEventAttribute("onTouchEnd")
+  lazy val onTouchMove = OnTouchEventAttribute("onTouchMove")
+  lazy val onTouchStart = OnTouchEventAttribute("onTouchStart")
+
+  // Transition Events
+  case class OnTransitionEventAttribute(name: String) extends OnEventAttribute[TransitionSyntheticEvent]
+
+  lazy val onTransitionEnd = OnTransitionEventAttribute("onTransitionEnd")
+
+  // UI Events
+  case class OnUIEventAttribute(name: String) extends OnEventAttribute[UISyntheticEvent]
+
+  lazy val onScroll = OnUIEventAttribute("onScroll")
+
+  // Wheel Events
+  case class OnWheelEventAttribute(name: String) extends OnEventAttribute[WheelSyntheticEvent]
+
+  lazy val onWheel = OnWheelEventAttribute("onWheel")
+
+  // Events that conflicted with other events
+  case class OnErrorEventAttribute(name: String) extends OnEventAttribute[SyntheticEvent]
+
+  lazy val onError = OnErrorEventAttribute("onError")
+}
+
 trait VirtualDOM extends StaticTags {
 
   class VirtualDOMElements extends Elements
 
-  class VirtualDOMAttributes extends Attributes {
-
-    case class OnEventAttribute(name: String) extends AttributeSpec {
-      def :=(callback: js.Function0[_]) = {
-        Attribute[js.Function0[_]](name = name, value = callback)
-      }
-
-      def :=[EVENT <: SyntheticEvent](callback: js.Function1[EVENT, _]) = {
-        Attribute[js.Function1[EVENT, _]](name = name, value = callback)
-      }
-    }
+  class VirtualDOMAttributes extends Attributes
+      with EventVirtualDOMAttributes {
 
     case class RefAttributeSpec(name: String) extends AttributeSpec {
-      def :=[T <: ReactHTMLElement](callback: js.Function1[T, Unit]) = {
-        Attribute[js.Function1[T, Unit]](name = name, value = callback)
+      def :=[T <: ReactHTMLElement](callback: js.Function1[T, _]): Attribute[js.Function1[T, _]] = {
+        Attribute(name = name, value = callback)
       }
     }
 
     lazy val className = SpaceSeparatedStringAttributeSpec(name = "className")
-    override lazy val `for` = htmlFor
+    override lazy val `for`: ForAttributeSpec = htmlFor
     lazy val htmlFor = ForAttributeSpec("htmlFor")
     lazy val key = StringAttributeSpec("key")
-    lazy val onChange = OnEventAttribute("onChange")
-    lazy val onSubmit = OnEventAttribute("onSubmit")
     lazy val ref = RefAttributeSpec("ref")
   }
 
@@ -79,6 +215,12 @@ trait VirtualDOM extends StaticTags {
 
   override val < = new VirtualDOMElements()
   override val ^ = new VirtualDOMAttributes()
+
+  implicit class RichElement(element: Element) {
+    def asReactElement: ReactElement = {
+      elementsToVirtualDoms(element)
+    }
+  }
 
   implicit def elementsToVirtualDoms(element: Element): ReactElement = {
     React.createElement(

--- a/core/src/main/scala/io/github/shogowada/scalajs/reactjs/events/FormSyntheticEvent.scala
+++ b/core/src/main/scala/io/github/shogowada/scalajs/reactjs/events/FormSyntheticEvent.scala
@@ -1,0 +1,25 @@
+package io.github.shogowada.scalajs.reactjs.events
+
+import io.github.shogowada.scalajs.reactjs.elements._
+
+import scala.scalajs.js
+
+@js.native
+trait FormSyntheticEvent[ELEMENT <: ReactHTMLElement] extends SyntheticEvent {
+  val target: ReactHTMLInputElement = js.native
+}
+
+@js.native
+trait CheckBoxFormSyntheticEvent extends FormSyntheticEvent[ReactHTMLCheckBoxElement]
+
+@js.native
+trait InputFormSyntheticEvent extends FormSyntheticEvent[ReactHTMLInputElement]
+
+@js.native
+trait OptionFormSyntheticEvent extends FormSyntheticEvent[ReactHTMLOptionElement]
+
+@js.native
+trait RadioFormSyntheticEvent extends FormSyntheticEvent[ReactHTMLRadioElement]
+
+@js.native
+trait TextAreaFormSyntheticEvent extends FormSyntheticEvent[ReactHTMLTextAreaElement]

--- a/core/src/main/scala/io/github/shogowada/scalajs/reactjs/events/SyntheticEvent.scala
+++ b/core/src/main/scala/io/github/shogowada/scalajs/reactjs/events/SyntheticEvent.scala
@@ -1,6 +1,6 @@
 package io.github.shogowada.scalajs.reactjs.events
 
-import io.github.shogowada.scalajs.reactjs.elements._
+import org.scalajs.dom.{DataTransfer, EventTarget, TouchList}
 
 import scala.scalajs.js
 
@@ -26,21 +26,106 @@ trait SyntheticEvent extends js.Object {
 }
 
 @js.native
-trait ElementSyntheticEvent[ELEMENT <: ReactHTMLElement] extends SyntheticEvent {
-  val target: ReactHTMLInputElement = js.native
+trait AnimationSyntheticEvent extends SyntheticEvent {
+  val animationName: String = js.native
+  val pseudoElement: String = js.native
+  val elapsedTime: Float = js.native
 }
 
 @js.native
-trait CheckBoxElementSyntheticEvent extends ElementSyntheticEvent[ReactHTMLCheckBoxElement]
+trait ClipboardSyntheticEvent extends SyntheticEvent {
+  val clipboardData: DataTransfer = js.native
+}
 
 @js.native
-trait InputElementSyntheticEvent extends ElementSyntheticEvent[ReactHTMLInputElement]
+trait CompositionSyntheticEvent extends SyntheticEvent {
+  val data: String = js.native
+}
 
 @js.native
-trait OptionElementSyntheticEvent extends ElementSyntheticEvent[ReactHTMLOptionElement]
+trait FocusSyntheticEvent extends SyntheticEvent {
+  val relatedTarget: EventTarget = js.native
+}
 
 @js.native
-trait RadioElementSyntheticEvent extends ElementSyntheticEvent[ReactHTMLRadioElement]
+trait ImageSyntheticEvent extends SyntheticEvent
 
 @js.native
-trait TextAreaElementSyntheticEvent extends ElementSyntheticEvent[ReactHTMLTextAreaElement]
+trait KeyboardSyntheticEvent extends SyntheticEvent {
+  val altKey: Boolean = js.native
+  val charCode: Int = js.native
+  val ctrlKey: Boolean = js.native
+
+  def getModifierState(key: String): Boolean = js.native
+
+  val key: String = js.native
+  val keyCode: Int = js.native
+  val locale: String = js.native
+  val location: Int = js.native
+  val metaKey: Boolean = js.native
+  val repeat: Boolean = js.native
+  val shiftKey: Boolean = js.native
+  val which: Int = js.native
+}
+
+@js.native
+trait MediaSyntheticEvent extends SyntheticEvent
+
+@js.native
+trait MouseSyntheticEvent extends SyntheticEvent {
+  val altKey: Boolean = js.native
+  val button: Int = js.native
+  val buttons: Int = js.native
+  val clientX: Int = js.native
+  val clientY: Int = js.native
+  val ctrlKey: Boolean = js.native
+
+  def getModifierState(key: String): Boolean = js.native
+
+  val metaKey: Boolean = js.native
+  val pageX: Int = js.native
+  val pageY: Int = js.native
+  val relatedTarget: EventTarget = js.native
+  val screenX: Int = js.native
+  val screenY: Int = js.native
+  val shiftKey: Boolean = js.native
+}
+
+@js.native
+trait SelectionSyntheticEvent extends SyntheticEvent
+
+@js.native
+trait TouchSyntheticEvent extends SyntheticEvent {
+  val altKey: Boolean = js.native
+  val changedTouches: TouchList = js.native
+  val ctrlKey: Boolean = js.native
+
+  def getModifierState(key: String): Boolean = js.native
+
+  val metaKey: Boolean = js.native
+  val shiftKey: Boolean = js.native
+  val targetTouches: TouchList = js.native
+  val touches: TouchList = js.native
+}
+
+@js.native
+trait TransitionSyntheticEvent extends SyntheticEvent {
+  val propertyName: String = js.native
+  val pseudoElement: String = js.native
+  val elapsedTime: Float = js.native
+}
+
+@js.native
+trait UISyntheticEvent extends SyntheticEvent {
+  val detail: Int = js.native
+  // TODO: What should be the type of AbstractView?
+  // val view: AbstractView
+}
+
+@js.native
+trait WheelSyntheticEvent extends SyntheticEvent {
+  val deltaMode: Int = js.native
+  val deltaX: Int = js.native
+  val deltaY: Int = js.native
+  val deltaZ: Int = js.native
+}

--- a/example/todo-app/README.md
+++ b/example/todo-app/README.md
@@ -94,7 +94,7 @@ class TodoApp extends ReactClassSpec {
     )
   }
 
-  val handleChange = (event: InputElementSyntheticEvent) => {
+  val handleChange = (event: InputFormSyntheticEvent) => {
     val newText = event.target.value
     setState(_.copy(text = newText))
   }
@@ -205,7 +205,7 @@ If your component is stateful, you can update the state by using ```setState``` 
 class TodoApp extends ReactClassSpec {
   case class State(items: Seq[Item], text: String)
 
-  val handleChange = (event: InputElementSyntheticEvent) => {
+  val handleChange = (event: InputFormSyntheticEvent) => {
     val newText = event.target.value
     setState(_.copy(text = newText))
   }

--- a/example/todo-app/src/main/scala/io/github/shogowada/scalajs/reactjs/example/todoapp/Main.scala
+++ b/example/todo-app/src/main/scala/io/github/shogowada/scalajs/reactjs/example/todoapp/Main.scala
@@ -3,7 +3,8 @@ package io.github.shogowada.scalajs.reactjs.example.todoapp
 import io.github.shogowada.scalajs.reactjs.ReactDOM
 import io.github.shogowada.scalajs.reactjs.VirtualDOM._
 import io.github.shogowada.scalajs.reactjs.classes.specs.{ReactClassSpec, StatelessReactClassSpec}
-import io.github.shogowada.scalajs.reactjs.events.{InputElementSyntheticEvent, SyntheticEvent}
+import io.github.shogowada.scalajs.reactjs.elements.ReactElement
+import io.github.shogowada.scalajs.reactjs.events.{InputFormSyntheticEvent, SyntheticEvent}
 import org.scalajs.dom
 
 import scala.scalajs.js
@@ -17,7 +18,7 @@ object Main extends JSApp {
 
       override type Props = TodoList.Props
 
-      override def render() = <.ul()(props.items.map(item => <.li(^.key := item.id)(item.text)))
+      override def render(): ReactElement = <.ul()(props.items.map(item => <.li(^.key := item.id)(item.text)))
     }
 
     object TodoList {
@@ -34,7 +35,7 @@ object Main extends JSApp {
 
       override def getInitialState() = State(items = Seq(), text = "")
 
-      override def render() = {
+      override def render(): ReactElement = {
         <.div()(
           <.h3()("TODO"),
           new TodoList()(TodoList.Props(items = state.items)),
@@ -45,12 +46,12 @@ object Main extends JSApp {
         )
       }
 
-      val handleChange = (event: InputElementSyntheticEvent) => {
+      private val handleChange = (event: InputFormSyntheticEvent) => {
         val newText = event.target.value
         setState(_.copy(text = newText))
       }
 
-      val handleSubmit = (event: SyntheticEvent) => {
+      private val handleSubmit = (event: SyntheticEvent) => {
         event.preventDefault()
         val newItem = Item(text = state.text, id = js.Date.now().toString)
         setState((previousState: State) => State(


### PR DESCRIPTION
- Support all the React events documented at [the official website](https://facebook.github.io/react/docs/events.html#supported-events).

Breaking changes:

- `ElementSyntheticEvent` is renamed to `FormSyntheticEvent`.
    - `CheckBoxElementSyntheticEvent` is renamed to `CheckBoxFormSyntheticEvent`.
    - `InputElementSyntheticEvent` is renamed to `InputFormSyntheticEvent`.
    - `OptionElementSyntheticEvent` is renamed to `OptionFormSyntheticEvent`.
    - `RadioElementSyntheticEvent` is renamed to `RadioFormSyntheticEvent`.
    - `TextAreaElementSyntheticEvent` is renamed to `TextAreaFormSyntheticEvent`.

Close https://github.com/shogowada/scalajs-reactjs/issues/7